### PR TITLE
Enable building with VS2019

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,6 @@
-build_script: 
+image: Visual Studio 2019
+
+build_script:
   - ps: .\build.ps1 -Target "Appveyor"
 
 # disable built-in tests.

--- a/build.cake
+++ b/build.cake
@@ -81,7 +81,7 @@ Task("Build")
             {
                 MSBuild(proj, CreateSettings());
             }
-            catch (Exception e)
+            catch
             {
                 // Just record and continue, since samples are independent
                 ErrorDetail.Add("     * " + projName + " build failed.");

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
     <package id="Cake" version="0.33.0" />
-    <package id="NUnit.ConsoleRunner" version="3.6.1" />
+    <package id="NUnit.ConsoleRunner" version="3.10.0" />
 </packages>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.20.0" />
+    <package id="Cake" version="0.33.0" />
     <package id="NUnit.ConsoleRunner" version="3.6.1" />
 </packages>


### PR DESCRIPTION
Otherwise if you only have VS2019 on your machine, building picks up MSBuild 14.0.23107.0 which fails each fsproj with:

> error MSB4057: The target "Build" does not exist in the project.